### PR TITLE
feat: add hermes-agent Docker image

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    nix-hermes-agent = {
+      url = "github:0xrsydn/nix-hermes-agent";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
     treefmt-nix = {
@@ -50,11 +55,12 @@
   };
 
   outputs =
-    inputs@{
+    inputs @{
       devenv,
       devlib,
       flake-parts,
       git-hooks,
+      nix-hermes-agent,
       treefmt-nix,
       ...
     }:
@@ -72,6 +78,9 @@
           pkgs,
           ...
         }:
+        let
+          hermes-agent-pkg = nix-hermes-agent.packages.${pkgs.system}.hermes-agent;
+        in
         with lib;
         {
           devenv.shells.default = {
@@ -147,6 +156,10 @@
             syncthing = pkgs.callPackage ./pkgs/syncthing { inherit (self'.packages) base; };
             vaultwarden = pkgs.callPackage ./pkgs/vaultwarden { inherit (self'.packages) base; };
             whisparr = pkgs.callPackage ./pkgs/whisparr { inherit (self'.packages) base; };
+            hermes-agent = pkgs.callPackage ./pkgs/hermes-agent {
+              inherit (self'.packages) base;
+              inherit hermes-agent-pkg;
+            };
           };
         };
       systems = [

--- a/pkgs/hermes-agent/default.nix
+++ b/pkgs/hermes-agent/default.nix
@@ -1,0 +1,35 @@
+{ base, pkgs, hermes-agent-pkg }:
+
+pkgs.dockerTools.streamLayeredImage {
+  name = "hermes-agent";
+  tag = "latest";
+  fromImage = base;
+
+  config = {
+    Entrypoint = [
+      "${hermes-agent-pkg}/bin/hermes"
+    ];
+    Env = [
+      "HERMES_HOME=/data/.hermes"
+    ];
+    Labels = {
+      "org.opencontainers.image.source" = "https://github.com/x-shikanime/niximgs";
+      "org.opencontainers.image.description" = "Hermes Agent by Nous Research — self-improving AI agent with persistent memory";
+      "org.opencontainers.image.licenses" = "MIT";
+    };
+    User = "1000:1000";
+    WorkingDir = "/data";
+    Volumes = {
+      "/data" = { };
+    };
+  };
+
+  contents = [
+    hermes-agent-pkg
+  ];
+
+  fakeRootCommands = ''
+    mkdir -p ./data/.hermes
+    chown 1000:1000 ./data/.hermes
+  '';
+}


### PR DESCRIPTION
## Summary

Adds a `hermes-agent` Docker image to the niximgs repository, built from the community Nix package ([0xrsydn/nix-hermes-agent](https://github.com/0xrsydn/nix-hermes-agent)) for [Hermes Agent](https://github.com/NousResearch/hermes-agent) by Nous Research.

## Changes

- **flake.nix**: Add `nix-hermes-agent` flake input, pass through to outputs
- **pkgs/hermes-agent/default.nix**: New Docker image using `dockerTools.streamLayeredImage`

## Image configuration

| Setting | Value |
|---------|-------|
| Entrypoint | `hermes` |
| HERMES_HOME | `/data/.hermes` |
| User | `1000:1000` |
| Volume | `/data` (state, sessions, memories, skills) |
| Base | `x-shikanime/niximgs:base` |
| License | MIT |

## Verification

- CI will build and publish through the existing Integration workflow
- Follows the same layered image pattern as existing packages (vaultwarden, syncthing, etc.)